### PR TITLE
Fix typo: duplicate chess piece

### DIFF
--- a/games/chess/chess.json
+++ b/games/chess/chess.json
@@ -28,7 +28,7 @@
                     "count": 2
                 },
                 {
-                    "type": "bishop",
+                    "type": "rook",
                     "count": 4
                 },
                 {


### PR DESCRIPTION
Pretty straightforward, this fixes the omission of the rook (bishop was listed twice instead).
