### PR TITLE
Add Phase 10 definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A collection of json files describing the pieces of board/card games
 ## About
 Games are broken down by folders within the `games` folder.
-Each game folder contains a JSON of the basic information of the game, and it's pieces.
+Each game folder contains a JSON of the basic information of the game, and its pieces.
 The folder may also contain images of boards, cards, or pieces related to the game.
 
 ## Included Games
@@ -40,7 +40,7 @@ The folder may also contain images of boards, cards, or pieces related to the ga
  - [x] One Night Ultimate Werewolf
  - [x] Operation
  - [ ] Pandemic
- - [ ] Phase 10
+ - [x] Phase 10
  - [ ] Pictionary
  - [x] Playing Cards
  - [ ] Reversi

--- a/games/phase-10/phase-10.json
+++ b/games/phase-10/phase-10.json
@@ -1,0 +1,245 @@
+{
+    "name": "Phase 10",
+    "publisher": "Mattel",
+    "edition": "W4729",
+    "pieces": {
+        "rulebook": {
+            "total_count": 1
+        },
+        "reference_card": {
+            "total_count": 2
+        },
+        "cards": [
+              {
+                  "type": "number",
+                  "color": "red",
+                  "total_count": 24,
+                  "values": [
+                      {
+                          "value": 1,
+                          "count": 2
+                      },
+                      {
+                          "value": 2,
+                          "count": 2
+                      },
+                      {
+                          "value": 3,
+                          "count": 2
+                      },
+                      {
+                          "value": 4,
+                          "count": 2
+                      },
+                      {
+                          "value": 5,
+                          "count": 2
+                      },
+                      {
+                          "value": 6,
+                          "count": 2
+                      },
+                      {
+                          "value": 7,
+                          "count": 2
+                      },
+                      {
+                          "value": 8,
+                          "count": 2
+                      },
+                      {
+                          "value": 9,
+                          "count": 2
+                      },
+                      {
+                          "value": 10,
+                          "count": 2
+                      },
+                      {
+                          "value": 11,
+                          "count": 2
+                      },
+                      {
+                          "value": 12,
+                          "count": 2
+                      }
+                  ]
+              },
+              {
+                  "type": "number",
+                  "color": "blue",
+                  "total_count": 24,
+                  "values": [
+                      {
+                          "value": 1,
+                          "count": 2
+                      },
+                      {
+                          "value": 2,
+                          "count": 2
+                      },
+                      {
+                          "value": 3,
+                          "count": 2
+                      },
+                      {
+                          "value": 4,
+                          "count": 2
+                      },
+                      {
+                          "value": 5,
+                          "count": 2
+                      },
+                      {
+                          "value": 6,
+                          "count": 2
+                      },
+                      {
+                          "value": 7,
+                          "count": 2
+                      },
+                      {
+                          "value": 8,
+                          "count": 2
+                      },
+                      {
+                          "value": 9,
+                          "count": 2
+                      },
+                      {
+                          "value": 10,
+                          "count": 2
+                      },
+                      {
+                          "value": 11,
+                          "count": 2
+                      },
+                      {
+                          "value": 12,
+                          "count": 2
+                      }
+                  ]
+              },
+              {
+                  "type": "number",
+                  "color": "green",
+                  "total_count": 24,
+                  "values": [
+                      {
+                          "value": 1,
+                          "count": 2
+                      },
+                      {
+                          "value": 2,
+                          "count": 2
+                      },
+                      {
+                          "value": 3,
+                          "count": 2
+                      },
+                      {
+                          "value": 4,
+                          "count": 2
+                      },
+                      {
+                          "value": 5,
+                          "count": 2
+                      },
+                      {
+                          "value": 6,
+                          "count": 2
+                      },
+                      {
+                          "value": 7,
+                          "count": 2
+                      },
+                      {
+                          "value": 8,
+                          "count": 2
+                      },
+                      {
+                          "value": 9,
+                          "count": 2
+                      },
+                      {
+                          "value": 10,
+                          "count": 2
+                      },
+                      {
+                          "value": 11,
+                          "count": 2
+                      },
+                      {
+                          "value": 12,
+                          "count": 2
+                      }
+                  ]
+              },
+              {
+                  "type": "number",
+                  "color": "yellow",
+                  "total_count": 24,
+                  "values": [
+                      {
+                          "value": 1,
+                          "count": 2
+                      },
+                      {
+                          "value": 2,
+                          "count": 2
+                      },
+                      {
+                          "value": 3,
+                          "count": 2
+                      },
+                      {
+                          "value": 4,
+                          "count": 2
+                      },
+                      {
+                          "value": 5,
+                          "count": 2
+                      },
+                      {
+                          "value": 6,
+                          "count": 2
+                      },
+                      {
+                          "value": 7,
+                          "count": 2
+                      },
+                      {
+                          "value": 8,
+                          "count": 2
+                      },
+                      {
+                          "value": 9,
+                          "count": 2
+                      },
+                      {
+                          "value": 10,
+                          "count": 2
+                      },
+                      {
+                          "value": 11,
+                          "count": 2
+                      },
+                      {
+                          "value": 12,
+                          "count": 2
+                      }
+                  ]
+              },
+              {
+                  "type": "skip",
+                  "color": "none",
+                  "count": 4
+              },
+              {
+                  "type": "wild",
+                  "color": "none",
+                  "count": 8
+              }
+        ]
+    }
+}

--- a/games/phase-10/phase-10.json
+++ b/games/phase-10/phase-10.json
@@ -10,236 +10,236 @@
             "total_count": 2
         },
         "cards": [
-              {
-                  "type": "number",
-                  "color": "red",
-                  "total_count": 24,
-                  "values": [
-                      {
-                          "value": 1,
-                          "count": 2
-                      },
-                      {
-                          "value": 2,
-                          "count": 2
-                      },
-                      {
-                          "value": 3,
-                          "count": 2
-                      },
-                      {
-                          "value": 4,
-                          "count": 2
-                      },
-                      {
-                          "value": 5,
-                          "count": 2
-                      },
-                      {
-                          "value": 6,
-                          "count": 2
-                      },
-                      {
-                          "value": 7,
-                          "count": 2
-                      },
-                      {
-                          "value": 8,
-                          "count": 2
-                      },
-                      {
-                          "value": 9,
-                          "count": 2
-                      },
-                      {
-                          "value": 10,
-                          "count": 2
-                      },
-                      {
-                          "value": 11,
-                          "count": 2
-                      },
-                      {
-                          "value": 12,
-                          "count": 2
-                      }
-                  ]
-              },
-              {
-                  "type": "number",
-                  "color": "blue",
-                  "total_count": 24,
-                  "values": [
-                      {
-                          "value": 1,
-                          "count": 2
-                      },
-                      {
-                          "value": 2,
-                          "count": 2
-                      },
-                      {
-                          "value": 3,
-                          "count": 2
-                      },
-                      {
-                          "value": 4,
-                          "count": 2
-                      },
-                      {
-                          "value": 5,
-                          "count": 2
-                      },
-                      {
-                          "value": 6,
-                          "count": 2
-                      },
-                      {
-                          "value": 7,
-                          "count": 2
-                      },
-                      {
-                          "value": 8,
-                          "count": 2
-                      },
-                      {
-                          "value": 9,
-                          "count": 2
-                      },
-                      {
-                          "value": 10,
-                          "count": 2
-                      },
-                      {
-                          "value": 11,
-                          "count": 2
-                      },
-                      {
-                          "value": 12,
-                          "count": 2
-                      }
-                  ]
-              },
-              {
-                  "type": "number",
-                  "color": "green",
-                  "total_count": 24,
-                  "values": [
-                      {
-                          "value": 1,
-                          "count": 2
-                      },
-                      {
-                          "value": 2,
-                          "count": 2
-                      },
-                      {
-                          "value": 3,
-                          "count": 2
-                      },
-                      {
-                          "value": 4,
-                          "count": 2
-                      },
-                      {
-                          "value": 5,
-                          "count": 2
-                      },
-                      {
-                          "value": 6,
-                          "count": 2
-                      },
-                      {
-                          "value": 7,
-                          "count": 2
-                      },
-                      {
-                          "value": 8,
-                          "count": 2
-                      },
-                      {
-                          "value": 9,
-                          "count": 2
-                      },
-                      {
-                          "value": 10,
-                          "count": 2
-                      },
-                      {
-                          "value": 11,
-                          "count": 2
-                      },
-                      {
-                          "value": 12,
-                          "count": 2
-                      }
-                  ]
-              },
-              {
-                  "type": "number",
-                  "color": "yellow",
-                  "total_count": 24,
-                  "values": [
-                      {
-                          "value": 1,
-                          "count": 2
-                      },
-                      {
-                          "value": 2,
-                          "count": 2
-                      },
-                      {
-                          "value": 3,
-                          "count": 2
-                      },
-                      {
-                          "value": 4,
-                          "count": 2
-                      },
-                      {
-                          "value": 5,
-                          "count": 2
-                      },
-                      {
-                          "value": 6,
-                          "count": 2
-                      },
-                      {
-                          "value": 7,
-                          "count": 2
-                      },
-                      {
-                          "value": 8,
-                          "count": 2
-                      },
-                      {
-                          "value": 9,
-                          "count": 2
-                      },
-                      {
-                          "value": 10,
-                          "count": 2
-                      },
-                      {
-                          "value": 11,
-                          "count": 2
-                      },
-                      {
-                          "value": 12,
-                          "count": 2
-                      }
-                  ]
-              },
-              {
-                  "type": "skip",
-                  "color": "none",
-                  "count": 4
-              },
-              {
-                  "type": "wild",
-                  "color": "none",
-                  "count": 8
-              }
+            {
+                "type": "number",
+                "color": "red",
+                "total_count": 24,
+                "values": [
+                    {
+                        "value": 1,
+                        "count": 2
+                    },
+                    {
+                        "value": 2,
+                        "count": 2
+                    },
+                    {
+                        "value": 3,
+                        "count": 2
+                    },
+                    {
+                        "value": 4,
+                        "count": 2
+                    },
+                    {
+                        "value": 5,
+                        "count": 2
+                    },
+                    {
+                        "value": 6,
+                        "count": 2
+                    },
+                    {
+                        "value": 7,
+                        "count": 2
+                    },
+                    {
+                        "value": 8,
+                        "count": 2
+                    },
+                    {
+                        "value": 9,
+                        "count": 2
+                    },
+                    {
+                        "value": 10,
+                        "count": 2
+                    },
+                    {
+                        "value": 11,
+                        "count": 2
+                    },
+                    {
+                        "value": 12,
+                        "count": 2
+                    }
+                ]
+            },
+            {
+                "type": "number",
+                "color": "blue",
+                "total_count": 24,
+                "values": [
+                    {
+                        "value": 1,
+                        "count": 2
+                    },
+                    {
+                        "value": 2,
+                        "count": 2
+                    },
+                    {
+                        "value": 3,
+                        "count": 2
+                    },
+                    {
+                        "value": 4,
+                        "count": 2
+                    },
+                    {
+                        "value": 5,
+                        "count": 2
+                    },
+                    {
+                        "value": 6,
+                        "count": 2
+                    },
+                    {
+                        "value": 7,
+                        "count": 2
+                    },
+                    {
+                        "value": 8,
+                        "count": 2
+                    },
+                    {
+                        "value": 9,
+                        "count": 2
+                    },
+                    {
+                        "value": 10,
+                        "count": 2
+                    },
+                    {
+                        "value": 11,
+                        "count": 2
+                    },
+                    {
+                        "value": 12,
+                        "count": 2
+                    }
+                ]
+            },
+            {
+                "type": "number",
+                "color": "green",
+                "total_count": 24,
+                "values": [
+                    {
+                        "value": 1,
+                        "count": 2
+                    },
+                    {
+                        "value": 2,
+                        "count": 2
+                    },
+                    {
+                        "value": 3,
+                        "count": 2
+                    },
+                    {
+                        "value": 4,
+                        "count": 2
+                    },
+                    {
+                        "value": 5,
+                        "count": 2
+                    },
+                    {
+                        "value": 6,
+                        "count": 2
+                    },
+                    {
+                        "value": 7,
+                        "count": 2
+                    },
+                    {
+                        "value": 8,
+                        "count": 2
+                    },
+                    {
+                        "value": 9,
+                        "count": 2
+                    },
+                    {
+                        "value": 10,
+                        "count": 2
+                    },
+                    {
+                        "value": 11,
+                        "count": 2
+                    },
+                    {
+                        "value": 12,
+                        "count": 2
+                    }
+                ]
+            },
+            {
+                "type": "number",
+                "color": "yellow",
+                "total_count": 24,
+                "values": [
+                    {
+                        "value": 1,
+                        "count": 2
+                    },
+                    {
+                        "value": 2,
+                        "count": 2
+                    },
+                    {
+                        "value": 3,
+                        "count": 2
+                    },
+                    {
+                        "value": 4,
+                        "count": 2
+                    },
+                    {
+                        "value": 5,
+                        "count": 2
+                    },
+                    {
+                        "value": 6,
+                        "count": 2
+                    },
+                    {
+                        "value": 7,
+                        "count": 2
+                    },
+                    {
+                        "value": 8,
+                        "count": 2
+                    },
+                    {
+                        "value": 9,
+                        "count": 2
+                    },
+                    {
+                        "value": 10,
+                        "count": 2
+                    },
+                    {
+                        "value": 11,
+                        "count": 2
+                    },
+                    {
+                        "value": 12,
+                        "count": 2
+                    }
+                ]
+            },
+            {
+                "type": "skip",
+                "color": "none",
+                "count": 4
+            },
+            {
+                "type": "wild",
+                "color": "none",
+                "count": 8
+            }
         ]
     }
 }

--- a/games/phase-10/phase-10.json
+++ b/games/phase-10/phase-10.json
@@ -9,237 +9,240 @@
         "reference_card": {
             "total_count": 2
         },
-        "cards": [
-            {
-                "type": "number",
-                "color": "red",
-                "total_count": 24,
-                "values": [
-                    {
-                        "value": 1,
-                        "count": 2
-                    },
-                    {
-                        "value": 2,
-                        "count": 2
-                    },
-                    {
-                        "value": 3,
-                        "count": 2
-                    },
-                    {
-                        "value": 4,
-                        "count": 2
-                    },
-                    {
-                        "value": 5,
-                        "count": 2
-                    },
-                    {
-                        "value": 6,
-                        "count": 2
-                    },
-                    {
-                        "value": 7,
-                        "count": 2
-                    },
-                    {
-                        "value": 8,
-                        "count": 2
-                    },
-                    {
-                        "value": 9,
-                        "count": 2
-                    },
-                    {
-                        "value": 10,
-                        "count": 2
-                    },
-                    {
-                        "value": 11,
-                        "count": 2
-                    },
-                    {
-                        "value": 12,
-                        "count": 2
-                    }
-                ]
-            },
-            {
-                "type": "number",
-                "color": "blue",
-                "total_count": 24,
-                "values": [
-                    {
-                        "value": 1,
-                        "count": 2
-                    },
-                    {
-                        "value": 2,
-                        "count": 2
-                    },
-                    {
-                        "value": 3,
-                        "count": 2
-                    },
-                    {
-                        "value": 4,
-                        "count": 2
-                    },
-                    {
-                        "value": 5,
-                        "count": 2
-                    },
-                    {
-                        "value": 6,
-                        "count": 2
-                    },
-                    {
-                        "value": 7,
-                        "count": 2
-                    },
-                    {
-                        "value": 8,
-                        "count": 2
-                    },
-                    {
-                        "value": 9,
-                        "count": 2
-                    },
-                    {
-                        "value": 10,
-                        "count": 2
-                    },
-                    {
-                        "value": 11,
-                        "count": 2
-                    },
-                    {
-                        "value": 12,
-                        "count": 2
-                    }
-                ]
-            },
-            {
-                "type": "number",
-                "color": "green",
-                "total_count": 24,
-                "values": [
-                    {
-                        "value": 1,
-                        "count": 2
-                    },
-                    {
-                        "value": 2,
-                        "count": 2
-                    },
-                    {
-                        "value": 3,
-                        "count": 2
-                    },
-                    {
-                        "value": 4,
-                        "count": 2
-                    },
-                    {
-                        "value": 5,
-                        "count": 2
-                    },
-                    {
-                        "value": 6,
-                        "count": 2
-                    },
-                    {
-                        "value": 7,
-                        "count": 2
-                    },
-                    {
-                        "value": 8,
-                        "count": 2
-                    },
-                    {
-                        "value": 9,
-                        "count": 2
-                    },
-                    {
-                        "value": 10,
-                        "count": 2
-                    },
-                    {
-                        "value": 11,
-                        "count": 2
-                    },
-                    {
-                        "value": 12,
-                        "count": 2
-                    }
-                ]
-            },
-            {
-                "type": "number",
-                "color": "yellow",
-                "total_count": 24,
-                "values": [
-                    {
-                        "value": 1,
-                        "count": 2
-                    },
-                    {
-                        "value": 2,
-                        "count": 2
-                    },
-                    {
-                        "value": 3,
-                        "count": 2
-                    },
-                    {
-                        "value": 4,
-                        "count": 2
-                    },
-                    {
-                        "value": 5,
-                        "count": 2
-                    },
-                    {
-                        "value": 6,
-                        "count": 2
-                    },
-                    {
-                        "value": 7,
-                        "count": 2
-                    },
-                    {
-                        "value": 8,
-                        "count": 2
-                    },
-                    {
-                        "value": 9,
-                        "count": 2
-                    },
-                    {
-                        "value": 10,
-                        "count": 2
-                    },
-                    {
-                        "value": 11,
-                        "count": 2
-                    },
-                    {
-                        "value": 12,
-                        "count": 2
-                    }
-                ]
-            },
-            {
-                "type": "skip",
-                "color": "none",
-                "count": 4
-            },
-            {
-                "type": "wild",
-                "color": "none",
-                "count": 8
-            }
-        ]
+        "cards": {
+            "total_count": 108,
+            "types": [
+                {
+                    "type": "number",
+                    "color": "red",
+                    "total_count": 24,
+                    "values": [
+                        {
+                            "value": 1,
+                            "count": 2
+                        },
+                        {
+                            "value": 2,
+                            "count": 2
+                        },
+                        {
+                            "value": 3,
+                            "count": 2
+                        },
+                        {
+                            "value": 4,
+                            "count": 2
+                        },
+                        {
+                            "value": 5,
+                            "count": 2
+                        },
+                        {
+                            "value": 6,
+                            "count": 2
+                        },
+                        {
+                            "value": 7,
+                            "count": 2
+                        },
+                        {
+                            "value": 8,
+                            "count": 2
+                        },
+                        {
+                            "value": 9,
+                            "count": 2
+                        },
+                        {
+                            "value": 10,
+                            "count": 2
+                        },
+                        {
+                            "value": 11,
+                            "count": 2
+                        },
+                        {
+                            "value": 12,
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "number",
+                    "color": "blue",
+                    "total_count": 24,
+                    "values": [
+                        {
+                            "value": 1,
+                            "count": 2
+                        },
+                        {
+                            "value": 2,
+                            "count": 2
+                        },
+                        {
+                            "value": 3,
+                            "count": 2
+                        },
+                        {
+                            "value": 4,
+                            "count": 2
+                        },
+                        {
+                            "value": 5,
+                            "count": 2
+                        },
+                        {
+                            "value": 6,
+                            "count": 2
+                        },
+                        {
+                            "value": 7,
+                            "count": 2
+                        },
+                        {
+                            "value": 8,
+                            "count": 2
+                        },
+                        {
+                            "value": 9,
+                            "count": 2
+                        },
+                        {
+                            "value": 10,
+                            "count": 2
+                        },
+                        {
+                            "value": 11,
+                            "count": 2
+                        },
+                        {
+                            "value": 12,
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "number",
+                    "color": "green",
+                    "total_count": 24,
+                    "values": [
+                        {
+                            "value": 1,
+                            "count": 2
+                        },
+                        {
+                            "value": 2,
+                            "count": 2
+                        },
+                        {
+                            "value": 3,
+                            "count": 2
+                        },
+                        {
+                            "value": 4,
+                            "count": 2
+                        },
+                        {
+                            "value": 5,
+                            "count": 2
+                        },
+                        {
+                            "value": 6,
+                            "count": 2
+                        },
+                        {
+                            "value": 7,
+                            "count": 2
+                        },
+                        {
+                            "value": 8,
+                            "count": 2
+                        },
+                        {
+                            "value": 9,
+                            "count": 2
+                        },
+                        {
+                            "value": 10,
+                            "count": 2
+                        },
+                        {
+                            "value": 11,
+                            "count": 2
+                        },
+                        {
+                            "value": 12,
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "number",
+                    "color": "yellow",
+                    "total_count": 24,
+                    "values": [
+                        {
+                            "value": 1,
+                            "count": 2
+                        },
+                        {
+                            "value": 2,
+                            "count": 2
+                        },
+                        {
+                            "value": 3,
+                            "count": 2
+                        },
+                        {
+                            "value": 4,
+                            "count": 2
+                        },
+                        {
+                            "value": 5,
+                            "count": 2
+                        },
+                        {
+                            "value": 6,
+                            "count": 2
+                        },
+                        {
+                            "value": 7,
+                            "count": 2
+                        },
+                        {
+                            "value": 8,
+                            "count": 2
+                        },
+                        {
+                            "value": 9,
+                            "count": 2
+                        },
+                        {
+                            "value": 10,
+                            "count": 2
+                        },
+                        {
+                            "value": 11,
+                            "count": 2
+                        },
+                        {
+                            "value": 12,
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "skip",
+                    "color": "none",
+                    "count": 4
+                },
+                {
+                    "type": "wild",
+                    "color": "none",
+                    "count": 8
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
I added the definition for Phase 10 using its [BoardGameGeek entry](http://boardgamegeek.com/boardgame/1258/phase-10) and its [Amazon product page](https://www.amazon.com/Phase-10-Card-Game-Styles/dp/B004MU9V8Q). I modeled it after the [Uno](https://github.com/daviscodesbugs/gamepiece-json/blob/master/games/uno/uno.json) definition since the games are so similar.

Some versions of the game have colored (red, blue, green, yellow) wild/skip cards, but the version I have has colorless wild/skip cards (which matches the publisher/edition in the definition).
