### PR TITLE
Add SET definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The folder may also contain images of boards, cards, or pieces related to the ga
  - [ ] Scum
  - [x] Senet
  - [ ] Sequence
- - [ ] Set
+ - [x] Set
  - [ ] _Settlers of Catan (in-progress)_
  - [x] Settlers of Catan - Cities & Knights Expansion
  - [x] Settlers of Catan - Explorers & Pirates Expansion

--- a/games/set/set.json
+++ b/games/set/set.json
@@ -1,0 +1,582 @@
+{
+    "name": "SET",
+    "publisher": "SET Enterprises",
+    "edition": "7-36396-00100-9",
+    "pieces": {
+        "rulebook": {
+            "total_count": 1
+        },
+        "cards": {
+            "total_count": 81,
+            "types": [
+                {
+                    "color": "red",
+                    "shading": "solid",
+                    "symbol": "oval",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "solid",
+                    "symbol": "oval",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "solid",
+                    "symbol": "oval",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "solid",
+                    "symbol": "squiggle",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "solid",
+                    "symbol": "squiggle",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "solid",
+                    "symbol": "squiggle",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "solid",
+                    "symbol": "diamond",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "solid",
+                    "symbol": "diamond",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "solid",
+                    "symbol": "diamond",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "striped",
+                    "symbol": "oval",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "striped",
+                    "symbol": "oval",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "striped",
+                    "symbol": "oval",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "striped",
+                    "symbol": "squiggle",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "striped",
+                    "symbol": "squiggle",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "striped",
+                    "symbol": "squiggle",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "striped",
+                    "symbol": "diamond",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "striped",
+                    "symbol": "diamond",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "striped",
+                    "symbol": "diamond",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "outlined",
+                    "symbol": "oval",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "outlined",
+                    "symbol": "oval",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "outlined",
+                    "symbol": "oval",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "outlined",
+                    "symbol": "squiggle",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "outlined",
+                    "symbol": "squiggle",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "outlined",
+                    "symbol": "squiggle",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "outlined",
+                    "symbol": "diamond",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "outlined",
+                    "symbol": "diamond",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "red",
+                    "shading": "outlined",
+                    "symbol": "diamond",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "solid",
+                    "symbol": "oval",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "solid",
+                    "symbol": "oval",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "solid",
+                    "symbol": "oval",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "solid",
+                    "symbol": "squiggle",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "solid",
+                    "symbol": "squiggle",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "solid",
+                    "symbol": "squiggle",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "solid",
+                    "symbol": "diamond",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "solid",
+                    "symbol": "diamond",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "solid",
+                    "symbol": "diamond",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "striped",
+                    "symbol": "oval",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "striped",
+                    "symbol": "oval",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "striped",
+                    "symbol": "oval",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "striped",
+                    "symbol": "squiggle",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "striped",
+                    "symbol": "squiggle",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "striped",
+                    "symbol": "squiggle",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "striped",
+                    "symbol": "diamond",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "striped",
+                    "symbol": "diamond",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "striped",
+                    "symbol": "diamond",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "outlined",
+                    "symbol": "oval",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "outlined",
+                    "symbol": "oval",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "outlined",
+                    "symbol": "oval",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "outlined",
+                    "symbol": "squiggle",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "outlined",
+                    "symbol": "squiggle",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "outlined",
+                    "symbol": "squiggle",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "outlined",
+                    "symbol": "diamond",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "outlined",
+                    "symbol": "diamond",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "purple",
+                    "shading": "outlined",
+                    "symbol": "diamond",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "solid",
+                    "symbol": "oval",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "solid",
+                    "symbol": "oval",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "solid",
+                    "symbol": "oval",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "solid",
+                    "symbol": "squiggle",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "solid",
+                    "symbol": "squiggle",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "solid",
+                    "symbol": "squiggle",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "solid",
+                    "symbol": "diamond",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "solid",
+                    "symbol": "diamond",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "solid",
+                    "symbol": "diamond",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "striped",
+                    "symbol": "oval",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "striped",
+                    "symbol": "oval",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "striped",
+                    "symbol": "oval",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "striped",
+                    "symbol": "squiggle",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "striped",
+                    "symbol": "squiggle",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "striped",
+                    "symbol": "squiggle",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "striped",
+                    "symbol": "diamond",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "striped",
+                    "symbol": "diamond",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "striped",
+                    "symbol": "diamond",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "outlined",
+                    "symbol": "oval",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "outlined",
+                    "symbol": "oval",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "outlined",
+                    "symbol": "oval",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "outlined",
+                    "symbol": "squiggle",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "outlined",
+                    "symbol": "squiggle",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "outlined",
+                    "symbol": "squiggle",
+                    "number": 3,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "outlined",
+                    "symbol": "diamond",
+                    "number": 1,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "outlined",
+                    "symbol": "diamond",
+                    "number": 2,
+                    "count": 1
+                },
+                {
+                    "color": "green",
+                    "shading": "outlined",
+                    "symbol": "diamond",
+                    "number": 3,
+                    "count": 1
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
I added the definition for SET, created from the [manufacturer's website](http://www.setgame.com/set), the [Amazon product page](https://www.amazon.com/SET-Family-Game-Visual-Perception/dp/B00000IV34), the [BGG entry](http://boardgamegeek.com/boardgame/1198/set), and my own copy.

Interestingly, every card in this game is unique. There are four attributes with three values for each attribute for a total of 3<sup>4</sup> = 81 cards.

I used the manufacturer's terminology and a script to generate all the cards to avoid errors:

``` ruby
require 'json'

colors = ['red', 'purple', 'green']
shadings = ['solid', 'striped', 'outlined']
symbols = ['oval', 'squiggle', 'diamond']
numbers = [1, 2, 3]

cards = colors.product(shadings, symbols, numbers).map do |c, sh, sy, n|
  { color: c, shading: sh, symbol: sy, number: n, count: 1 }
end

puts JSON.pretty_generate(cards, indent: '    ')
```
